### PR TITLE
Using the new Date().getFullYear to get year

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -48,7 +48,7 @@ function Footer(props) {
           </nav>
           <div className="credits ml-auto">
             <div className="copyright">
-              &copy; {1900 + new Date().getYear()}, made with{" "}
+              &copy; {new Date().getFullYear()}, made with{" "}
               <i className="fa fa-heart heart" /> by Creative Tim
             </div>
           </div>


### PR DESCRIPTION
# Changed log

- Using the `new Date().getFullYear()` to get the current year simply.